### PR TITLE
Allow modal props overriding, handle overflow

### DIFF
--- a/src/components/Modal/Modal.styled.ts
+++ b/src/components/Modal/Modal.styled.ts
@@ -55,6 +55,9 @@ export const ModalTitle = styled(GradientText)`
 `
 export const ModalBody = styled.div`
   padding: 0 30px 30px;
+
+  max-height: 80vh;
+  overflow-y: auto;
 `
 export const IconsWrapper = styled.div`
   display: flex;


### PR DESCRIPTION
This PR aims to decouple the title / secondaryIcon actions, which may be set per page, from the component, where the modal is present.