### PR TITLE
Fix iOS mobile navbar

### DIFF
--- a/src/components/Layout/Header/MobileNavBar/MobileNavBar.styled.ts
+++ b/src/components/Layout/Header/MobileNavBar/MobileNavBar.styled.ts
@@ -7,8 +7,11 @@ export const SMobileNavBar = styled.div`
   bottom: 0;
   z-index: ${theme.zIndices.header};
 
+  padding-bottom: env(safe-area-inset-bottom);
+
   height: var(--mobile-nav-height);
   width: 100%;
+  transition: all ${theme.transitions.default};
 
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(64px, 1fr));

--- a/src/components/Layout/Page/Page.styled.ts
+++ b/src/components/Layout/Page/Page.styled.ts
@@ -2,7 +2,7 @@ import styled from "@emotion/styled"
 import { theme } from "theme"
 
 export const SPage = styled.div`
-  --mobile-nav-height: 54px;
+  --mobile-nav-height: calc(54px + env(safe-area-inset-bottom));
 
   position: relative;
 


### PR DESCRIPTION
On iOS, the mobile navbar is being covered by the navigation pill

![image](https://user-images.githubusercontent.com/1443449/196661810-18a21e68-ae62-487f-bb55-10b02257ed6a.png)
