### PR TITLE
fix: Vesting refactoring and fixed values

### DIFF
--- a/src/api/balances.ts
+++ b/src/api/balances.ts
@@ -78,3 +78,15 @@ export function useTokensBalances(
     })),
   })
 }
+
+const getExistentialDeposit = (api: ApiPromise) => {
+  return api.consts.balances.existentialDeposit
+}
+
+export function useExistentialDeposit() {
+  const api = useApiPromise()
+  return useQuery(QUERY_KEYS.existentialDeposit, async () => {
+    const existentialDeposit = await getExistentialDeposit(api)
+    return existentialDeposit.toBigNumber()
+  })
+}

--- a/src/api/vesting.ts
+++ b/src/api/vesting.ts
@@ -11,6 +11,7 @@ import { BLOCK_TIME, BN_0, ORMLVEST } from "utils/constants"
 import { useMemo } from "react"
 import { useApiPromise } from "utils/api"
 import { getExpectedBlockDate } from "../utils/block"
+import { compareAsc } from "date-fns"
 
 export const useVestingSchedules = (address: Maybe<AccountId32 | string>) => {
   const api = useApiPromise()
@@ -35,11 +36,12 @@ export const useVestingLockBalance = (address: Maybe<AccountId32 | string>) => {
 const getVestingLockBalance =
   (api: ApiPromise, address: AccountId32 | string) => async () => {
     const data = await api.query.balances.locks(address)
-    return (
-      data
-        .find((lock) => lock.id.toString() === ORMLVEST)
-        ?.amount.toBigNumber() ?? BN_0
-    )
+
+    const amount = data
+      .find((lock) => lock.id.toHuman() === ORMLVEST)
+      ?.amount.toBigNumber()
+
+    return amount ?? null
   }
 
 export const getVestingSchedules =
@@ -58,78 +60,69 @@ const getScheduleClaimableBalance = (
   const start = schedule.start.toBigNumber()
   const period = schedule.period.toBigNumber()
   const periodCount = schedule.periodCount.toBigNumber()
+  const perPeriod = new BigNumber(schedule.perPeriod.toHex())
   const blockNumberAsBigNumber = blockNumber.toBigNumber()
+  const currentPeriod = blockNumberAsBigNumber.minus(start).div(period)
 
-  const numOfPeriods = blockNumberAsBigNumber.minus(start).div(period)
+  const numOfPeriods = new BigNumber(
+    Math.floor(
+      currentPeriod.isGreaterThan(periodCount)
+        ? periodCount.toNumber()
+        : currentPeriod.toNumber(),
+    ),
+  )
+
   const vestedOverPeriods = numOfPeriods.times(
     new BigNumber(schedule.perPeriod.toHex()),
   )
-  const originalLock = periodCount.times(
-    new BigNumber(schedule.perPeriod.toHex()),
-  )
-
-  return originalLock.minus(vestedOverPeriods)
-}
-
-/**
- * Returns date of next available claim
- **/
-export const useNextClaimableDate = (schedule: ScheduleType) => {
-  const bestNumberQuery = useBestNumber()
-  const start = schedule.start.toBigNumber()
-  const period = schedule.period.toBigNumber()
-
-  const periodNumber = useMemo(() => {
-    if (bestNumberQuery.data) {
-      const blockNumber =
-        bestNumberQuery.data.relaychainBlockNumber.toBigNumber()
-      return blockNumber.minus(start).div(period)
-    }
-    return null
-  }, [bestNumberQuery, start, period])
-
-  const nextClaimingBlock = useMemo(() => {
-    if (periodNumber) {
-      return new BigNumber(
-        Math.ceil(start.plus(periodNumber).times(period).toNumber()),
-      )
-    }
-    return null
-  }, [periodNumber, start, period])
-
-  const nextClaimableDate = useMemo(() => {
-    if (bestNumberQuery.data && nextClaimingBlock) {
-      const currentBlockNumber =
-        bestNumberQuery.data.relaychainBlockNumber.toBigNumber()
-      return getExpectedBlockDate(currentBlockNumber, nextClaimingBlock)
-    }
-    return null
-  }, [bestNumberQuery, nextClaimingBlock])
 
   return {
-    data: nextClaimableDate,
-    isLoading: bestNumberQuery.isLoading,
+    originalLock: periodCount.times(perPeriod),
+    vestedOverPeriods,
   }
 }
 
+const getNextClaimableDate = (
+  schedule: ScheduleType,
+  blockNumber: BigNumber,
+) => {
+  const start = schedule.start.toBigNumber()
+  const period = schedule.period.toBigNumber()
+  const periodNumber = blockNumber.minus(start).div(period)
+  const nextClaimingBlock = new BigNumber(
+    Math.ceil(start.plus(periodNumber).times(period).toNumber()),
+  )
+  return getExpectedBlockDate(blockNumber, nextClaimingBlock)
+}
+
 /**
- * Returns Bignumber of claimable balance in one schedule
+ * Returns first claimable date of all vestings
  **/
-export const useVestingScheduleClaimableBalance = (schedule: ScheduleType) => {
+export const useNextClaimableDate = () => {
+  const { account } = useAccountStore()
+  const { data: schedules } = useVestingSchedules(account?.address)
   const bestNumberQuery = useBestNumber()
 
-  const claimableBalance = useMemo(() => {
-    if (bestNumberQuery.data) {
-      return getScheduleClaimableBalance(
-        schedule,
-        bestNumberQuery.data.relaychainBlockNumber,
+  const nextClaimableDates = useMemo(() => {
+    if (bestNumberQuery.data && schedules) {
+      const blockNumber =
+        bestNumberQuery.data.relaychainBlockNumber.toBigNumber()
+      return schedules.map((schedule) =>
+        getNextClaimableDate(schedule, blockNumber),
       )
     }
     return null
-  }, [schedule, bestNumberQuery])
+  }, [schedules, bestNumberQuery.data])
+
+  const nextClaimableDate = useMemo(() => {
+    if (nextClaimableDates) {
+      return nextClaimableDates.sort(compareAsc)[0]
+    }
+    return null
+  }, [nextClaimableDates])
 
   return {
-    data: claimableBalance,
+    data: nextClaimableDate,
     isLoading: bestNumberQuery.isLoading,
   }
 }
@@ -153,13 +146,13 @@ export const useVestingTotalClaimableBalance = () => {
       vestingLockBalanceQuery.data
     ) {
       const futureLocks = vestingSchedulesQuery.data.reduce((acc, cur) => {
-        acc.plus(
-          getScheduleClaimableBalance(
-            cur,
-            bestNumberQuery.data.relaychainBlockNumber,
-          ),
+        const claimable = getScheduleClaimableBalance(
+          cur,
+          bestNumberQuery.data.relaychainBlockNumber,
         )
-        return acc
+        return acc.plus(
+          claimable.originalLock.minus(claimable.vestedOverPeriods),
+        )
       }, BN_0)
 
       return vestingLockBalanceQuery.data.minus(futureLocks)
@@ -190,8 +183,7 @@ export const useVestingTotalVestedAmount = () => {
       return data.reduce((acc, cur) => {
         const perPeriod = new BigNumber(cur.perPeriod.toHex())
         const periodCount = new BigNumber(cur.periodCount.toHex())
-        acc.plus(perPeriod.times(periodCount))
-        return acc
+        return acc.plus(perPeriod.times(periodCount))
       }, BN_0)
     }
 

--- a/src/sections/wallet/vesting/WalletVestingBox.tsx
+++ b/src/sections/wallet/vesting/WalletVestingBox.tsx
@@ -17,15 +17,7 @@ export const WalletVestingBox = () => {
     }
 
     if (data) {
-      return !!data.length ? (
-        <>
-          {data.map((schedule, key) => (
-            <WalletVestingSchedule schedule={schedule} key={key} />
-          ))}
-        </>
-      ) : (
-        <WalletVestingEmpty />
-      )
+      return !!data.length ? <WalletVestingSchedule /> : <WalletVestingEmpty />
     }
 
     return null

--- a/src/sections/wallet/vesting/WalletVestingHeader.tsx
+++ b/src/sections/wallet/vesting/WalletVestingHeader.tsx
@@ -155,9 +155,11 @@ export const WalletVestingHeader = () => {
             </Text>
             <Text color="white" fs={18} fw={700}>
               {t("wallet.vesting.vesting_days_left_value", {
-                count: Math.ceil(
-                  vestingScheduleEnd.div(DAY_IN_MILLISECONDS).toNumber(),
-                ),
+                count: vestingScheduleEnd.div(DAY_IN_MILLISECONDS).isLessThan(0)
+                  ? 0
+                  : Math.ceil(
+                      vestingScheduleEnd.div(DAY_IN_MILLISECONDS).toNumber(),
+                    ),
               })}
             </Text>
           </div>

--- a/src/utils/queryKeys.ts
+++ b/src/utils/queryKeys.ts
@@ -134,4 +134,5 @@ export const QUERY_KEYS = {
   ],
   provider: (url: string) => ["provider", url],
   math: ["@galacticcouncil/math"],
+  existentialDeposit: ["existentialDeposit"],
 } as const


### PR DESCRIPTION
Based on discord call with Juraj and Kuba we needed to completely refactor vesting page

## What was changed:

- We will show only one vesting all time
- Showing same number in the box

![image](https://user-images.githubusercontent.com/104817596/200930850-99646bba-078a-4e47-8c72-91b993d7b019.png)

-  If there are multiple vesting we will show the first nearest date

![image](https://user-images.githubusercontent.com/104817596/200930901-76acbca4-ac75-4fea-99a7-46d8ae4d61d3.png)

## Fixed
- Total vested amount number
- Total claimable value
- Existential deposit calculation

## Features
- to prevent negative numbers - if vesting ended all related math is calculated with vesting end block 


 