### PR TITLE
feat(HYDRA-310): add Nova Wallet button when detected

### DIFF
--- a/src/polkadot.d.ts
+++ b/src/polkadot.d.ts
@@ -11,5 +11,6 @@ declare module "@polkadot/types-codec/abstract" {
 declare global {
   interface Window {
     injectedWeb3?: Record<string, InjectedWindowProvider>
+    walletExtension?: { isNovaWallet?: boolean }
   }
 }

--- a/src/sections/wallet/connect/modal/WalletConnectActiveFooter.styled.ts
+++ b/src/sections/wallet/connect/modal/WalletConnectActiveFooter.styled.ts
@@ -9,8 +9,6 @@ export const SContainer = styled.div`
   align-items: center;
   justify-content: space-between;
 
-  background: ${theme.colors.backgroundGray1000};
-
   margin: 0px -30px -30px;
   width: calc(100% + 30px * 2);
 
@@ -18,7 +16,12 @@ export const SContainer = styled.div`
   border-top-left-radius: 0px;
   border-top-right-radius: 0px;
 
-  padding: 20px 30px;
+  padding: 10px 30px;
+
+  @media ${theme.viewport.gte.sm} {
+    padding: 20px 30px;
+    background: ${theme.colors.backgroundGray1000};
+  }
 `
 
 export const SLogoutContainer = styled.div`

--- a/src/sections/wallet/connect/modal/WalletConnectActiveFooter.tsx
+++ b/src/sections/wallet/connect/modal/WalletConnectActiveFooter.tsx
@@ -12,6 +12,8 @@ import {
   SSwitchText,
 } from "./WalletConnectActiveFooter.styled"
 import { getWalletBySource } from "@talismn/connect-wallets"
+import { getWalletMeta } from "./WalletConnectModal.utils"
+import { useMedia } from "react-use"
 
 export function WalletConnectActiveFooter(props: {
   account: Account | undefined
@@ -21,6 +23,10 @@ export function WalletConnectActiveFooter(props: {
 }) {
   const { t } = useTranslation()
   const wallet = getWalletBySource(props.provider)
+
+  const isDesktop = useMedia(theme.viewport.gte.sm)
+  const isNovaWallet = window.walletExtension?.isNovaWallet || !isDesktop
+  const walletMeta = getWalletMeta(wallet, isNovaWallet)
 
   return (
     <SContainer>
@@ -41,13 +47,13 @@ export function WalletConnectActiveFooter(props: {
         <div sx={{ flex: "row", gap: 22, align: "center" }}>
           <div sx={{ flex: "row", gap: 12, align: "center" }}>
             <img
-              src={wallet?.logo.src}
-              alt={wallet?.logo.alt}
+              src={walletMeta?.logo.src}
+              alt={walletMeta?.logo.alt}
               width={30}
               height={30}
             />
             <Text fs={14} fw={600} css={{ color: theme.colors.neutralGray100 }}>
-              {wallet?.title}
+              {walletMeta?.title}
             </Text>
           </div>
           <SSwitchText fs={14} fw={500}>

--- a/src/sections/wallet/connect/modal/WalletConnectModal.utils.ts
+++ b/src/sections/wallet/connect/modal/WalletConnectModal.utils.ts
@@ -1,0 +1,36 @@
+import { Wallet } from "@talismn/connect-wallets"
+
+export const getWalletMeta = (
+  wallet: Wallet | undefined,
+  isNovaWallet: boolean,
+) => {
+  if (!wallet) return undefined
+
+  let walletMeta = {
+    title: wallet.title,
+    variant: wallet.extensionName,
+    installUrl: wallet.installUrl,
+    logo: {
+      src: wallet.logo.src,
+      alt: wallet.logo.alt,
+    },
+  } as const
+
+  // Nova Wallet acts as polkadot-js wallet
+  // But uses the same extension name, thus we need to just
+  // override the label
+  if (wallet.extensionName === "polkadot-js" && isNovaWallet) {
+    walletMeta = {
+      ...walletMeta,
+      variant: "nova-wallet",
+      title: "Nova Wallet",
+      installUrl: "https://novawallet.io/",
+      logo: {
+        src: `data:image/svg+xml,%3Csvg width='32' height='32' viewBox='0 0 32 32' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='32' height='32' rx='16' fill='url(%23paint0_linear_108_351)'/%3E%3Cpath d='M15.6222 6.5634C15.5937 6.43205 15.4063 6.43205 15.3778 6.5634L14.0382 12.742C13.789 13.8913 12.8913 14.789 11.742 15.0382L5.5634 16.3778C5.43205 16.4063 5.43205 16.5937 5.5634 16.6222L11.742 17.9618C12.8913 18.211 13.789 19.1087 14.0382 20.258L15.3778 26.4366C15.4063 26.5679 15.5937 26.5679 15.6222 26.4366L16.9618 20.258C17.211 19.1087 18.1087 18.211 19.258 17.9618L25.4366 16.6222C25.5679 16.5937 25.5679 16.4063 25.4366 16.3778L19.258 15.0382C18.1087 14.789 17.211 13.8913 16.9618 12.742L15.6222 6.5634Z' fill='white'/%3E%3Cdefs%3E%3ClinearGradient id='paint0_linear_108_351' x1='7' y1='32' x2='24' y2='-8.12113e-07' gradientUnits='userSpaceOnUse'%3E%3Cstop stop-color='%237CBAE5'/%3E%3Cstop offset='0.416667' stop-color='%233A56D1'/%3E%3Cstop offset='0.703125' stop-color='%23461764'/%3E%3Cstop offset='0.911458' stop-color='%23171523'/%3E%3C/linearGradient%3E%3C/defs%3E%3C/svg%3E%0A`,
+        alt: "Nova Wallet",
+      },
+    }
+  }
+
+  return walletMeta
+}

--- a/src/sections/wallet/connect/providers/WalletConnectProviders.styled.ts
+++ b/src/sections/wallet/connect/providers/WalletConnectProviders.styled.ts
@@ -32,6 +32,20 @@ export const SWalletButton = styled.button<{
       `
     }
 
+    if (variant === "nova-wallet") {
+      return css`
+        background: hsla(214, 65%, 64%, 0.05);
+
+        :hover {
+          background: hsla(214, 65%, 64%, 0.1);
+        }
+
+        :active {
+          background: hsla(214, 65%, 64%, 0.12);
+        }
+      `
+    }
+
     if (variant === "talisman") {
       return css`
         background: hsla(75, 100%, 68%, 0.05);

--- a/src/sections/wallet/connect/providers/WalletConnectProviders.tsx
+++ b/src/sections/wallet/connect/providers/WalletConnectProviders.tsx
@@ -1,10 +1,13 @@
 import { WalletConnectProvidersButton } from "sections/wallet/connect/providers/button/WalletConnectProvidersButton"
 import { FC } from "react"
 import { getWallets, Wallet } from "@talismn/connect-wallets"
+import { useMedia } from "react-use"
+import { theme } from "theme"
+import { getWalletMeta } from "../modal/WalletConnectModal.utils"
 
 type Props = {
   onConnect: (provider: Wallet) => void
-  onDownload: (provider: Wallet) => void
+  onDownload: (provider: { installUrl: string }) => void
 }
 
 export const WalletConnectProviders: FC<Props> = ({
@@ -12,6 +15,8 @@ export const WalletConnectProviders: FC<Props> = ({
   onDownload,
 }) => {
   const wallets = getWallets()
+  const isDesktop = useMedia(theme.viewport.gte.sm)
+  const isNovaWallet = window.walletExtension?.isNovaWallet || !isDesktop
 
   return (
     <div sx={{ flex: "column", align: "stretch", mt: 8, gap: 8 }}>
@@ -20,9 +25,14 @@ export const WalletConnectProviders: FC<Props> = ({
           <WalletConnectProvidersButton
             key={wallet.extensionName}
             wallet={wallet}
+            isNovaWallet={isNovaWallet}
             onClick={() => {
-              if (wallet.installed) onConnect(wallet)
-              else onDownload(wallet)
+              if (wallet.installed) {
+                onConnect(wallet)
+              } else {
+                const walletMeta = getWalletMeta(wallet, isNovaWallet)
+                if (walletMeta) onDownload(walletMeta)
+              }
             }}
             isInjected={!!wallet.installed}
           />

--- a/src/sections/wallet/connect/providers/button/WalletConnectProvidersButton.tsx
+++ b/src/sections/wallet/connect/providers/button/WalletConnectProvidersButton.tsx
@@ -20,11 +20,44 @@ export const WalletConnectProvidersButton: FC<Props> = ({
 }) => {
   const { t } = useTranslation()
 
+  let walletMeta = {
+    title: wallet.title,
+    variant: wallet.extensionName,
+
+    logo: {
+      src: wallet.logo.src,
+      alt: wallet.logo.alt,
+    },
+  } as const
+
+  // Nova Wallet acts as polkadot-js wallet
+  // But uses the same extension name, thus we need to just
+  // override the label
+  if (
+    wallet.extensionName === "polkadot-js" &&
+    window.walletExtension?.isNovaWallet
+  ) {
+    walletMeta = {
+      ...walletMeta,
+      variant: "nova-wallet",
+      logo: {
+        src: `data:image/svg+xml,%3Csvg width='32' height='32' viewBox='0 0 32 32' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='32' height='32' rx='16' fill='url(%23paint0_linear_108_351)'/%3E%3Cpath d='M15.6222 6.5634C15.5937 6.43205 15.4063 6.43205 15.3778 6.5634L14.0382 12.742C13.789 13.8913 12.8913 14.789 11.742 15.0382L5.5634 16.3778C5.43205 16.4063 5.43205 16.5937 5.5634 16.6222L11.742 17.9618C12.8913 18.211 13.789 19.1087 14.0382 20.258L15.3778 26.4366C15.4063 26.5679 15.5937 26.5679 15.6222 26.4366L16.9618 20.258C17.211 19.1087 18.1087 18.211 19.258 17.9618L25.4366 16.6222C25.5679 16.5937 25.5679 16.4063 25.4366 16.3778L19.258 15.0382C18.1087 14.789 17.211 13.8913 16.9618 12.742L15.6222 6.5634Z' fill='white'/%3E%3Cdefs%3E%3ClinearGradient id='paint0_linear_108_351' x1='7' y1='32' x2='24' y2='-8.12113e-07' gradientUnits='userSpaceOnUse'%3E%3Cstop stop-color='%237CBAE5'/%3E%3Cstop offset='0.416667' stop-color='%233A56D1'/%3E%3Cstop offset='0.703125' stop-color='%23461764'/%3E%3Cstop offset='0.911458' stop-color='%23171523'/%3E%3C/linearGradient%3E%3C/defs%3E%3C/svg%3E%0A`,
+        alt: "Nova Wallet",
+      },
+      title: "Nova Wallet",
+    }
+  }
+
   return (
-    <SWalletButton onClick={onClick} variant={wallet.extensionName}>
-      <img src={wallet.logo.src} alt={wallet.logo.alt} width={40} height={40} />
+    <SWalletButton onClick={onClick} variant={walletMeta.variant}>
+      <img
+        src={walletMeta.logo.src}
+        alt={walletMeta.logo.alt}
+        width={40}
+        height={40}
+      />
       <Text fs={18} css={{ flexGrow: 1 }}>
-        {wallet.title}
+        {walletMeta.title}
       </Text>
 
       <Text

--- a/src/sections/wallet/connect/providers/button/WalletConnectProvidersButton.tsx
+++ b/src/sections/wallet/connect/providers/button/WalletConnectProvidersButton.tsx
@@ -6,48 +6,25 @@ import { ReactComponent as ChevronRight } from "assets/icons/ChevronRight.svg"
 import { ReactComponent as DownloadIcon } from "assets/icons/DownloadIcon.svg"
 import { useTranslation } from "react-i18next"
 import { Wallet } from "@talismn/connect-wallets"
+import { getWalletMeta } from "sections/wallet/connect/modal/WalletConnectModal.utils"
 
 type Props = {
   wallet: Wallet
   onClick: () => void
   isInjected: boolean
+  isNovaWallet: boolean
 }
 
 export const WalletConnectProvidersButton: FC<Props> = ({
   wallet,
   onClick,
   isInjected,
+  isNovaWallet,
 }) => {
   const { t } = useTranslation()
+  const walletMeta = getWalletMeta(wallet, isNovaWallet)
 
-  let walletMeta = {
-    title: wallet.title,
-    variant: wallet.extensionName,
-
-    logo: {
-      src: wallet.logo.src,
-      alt: wallet.logo.alt,
-    },
-  } as const
-
-  // Nova Wallet acts as polkadot-js wallet
-  // But uses the same extension name, thus we need to just
-  // override the label
-  if (
-    wallet.extensionName === "polkadot-js" &&
-    window.walletExtension?.isNovaWallet
-  ) {
-    walletMeta = {
-      ...walletMeta,
-      variant: "nova-wallet",
-      logo: {
-        src: `data:image/svg+xml,%3Csvg width='32' height='32' viewBox='0 0 32 32' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='32' height='32' rx='16' fill='url(%23paint0_linear_108_351)'/%3E%3Cpath d='M15.6222 6.5634C15.5937 6.43205 15.4063 6.43205 15.3778 6.5634L14.0382 12.742C13.789 13.8913 12.8913 14.789 11.742 15.0382L5.5634 16.3778C5.43205 16.4063 5.43205 16.5937 5.5634 16.6222L11.742 17.9618C12.8913 18.211 13.789 19.1087 14.0382 20.258L15.3778 26.4366C15.4063 26.5679 15.5937 26.5679 15.6222 26.4366L16.9618 20.258C17.211 19.1087 18.1087 18.211 19.258 17.9618L25.4366 16.6222C25.5679 16.5937 25.5679 16.4063 25.4366 16.3778L19.258 15.0382C18.1087 14.789 17.211 13.8913 16.9618 12.742L15.6222 6.5634Z' fill='white'/%3E%3Cdefs%3E%3ClinearGradient id='paint0_linear_108_351' x1='7' y1='32' x2='24' y2='-8.12113e-07' gradientUnits='userSpaceOnUse'%3E%3Cstop stop-color='%237CBAE5'/%3E%3Cstop offset='0.416667' stop-color='%233A56D1'/%3E%3Cstop offset='0.703125' stop-color='%23461764'/%3E%3Cstop offset='0.911458' stop-color='%23171523'/%3E%3C/linearGradient%3E%3C/defs%3E%3C/svg%3E%0A`,
-        alt: "Nova Wallet",
-      },
-      title: "Nova Wallet",
-    }
-  }
-
+  if (!walletMeta) return null
   return (
     <SWalletButton onClick={onClick} variant={walletMeta.variant}>
       <img

--- a/src/sections/wallet/upgrade/WalletUpgradeModal.utils.ts
+++ b/src/sections/wallet/upgrade/WalletUpgradeModal.utils.ts
@@ -61,7 +61,7 @@ export const useUpdateMetadataMutation = () => {
       return {
         currVersion: known?.specVersion.toString(),
         nextVersion: api.runtimeVersion.specVersion?.toString(),
-        needsUpdate,
+        needsUpdate: !window.walletExtension?.isNovaWallet && needsUpdate,
       }
     },
     { enabled: account != null },


### PR DESCRIPTION
When Nova Wallet is detected, replace polkadot-js entry with Nova Wallet button. 

The logic is mostly the same, with the exception of manifest upgrading, where it doesn't seem to work properly. 